### PR TITLE
Add functionality for 'whatsup' command

### DIFF
--- a/app/controllers/api/mentions_controller.rb
+++ b/app/controllers/api/mentions_controller.rb
@@ -1,5 +1,7 @@
 module Api
   class MentionsController < ApplicationController
+    before_action :return_challenge, if: :challenge_param_present?
+
     def create
       user = User.find_or_create_by(slack_id: event_params[:user])
 
@@ -14,6 +16,14 @@ module Api
 
     def event_params
       params.require(:event).permit(:user, :ts, :text, :channel)
+    end
+
+    def challenge_param_present?
+      params[:challenge].present?
+    end
+
+    def return_challenge
+      render json: { challenge: params[:challenge] }
     end
   end
 end

--- a/app/models/turnip_price_record.rb
+++ b/app/models/turnip_price_record.rb
@@ -4,4 +4,12 @@ class TurnipPriceRecord < ApplicationRecord
   validates :price, :date, :time_period, presence: true
 
   enum time_period: { am: 0, pm: 1 }
+
+  scope :current_top_prices, -> do
+    where(
+      "date = ? AND time_period = ?",
+      Time.use_zone("Pacific Time (US & Canada)") { Time.zone.today },
+      Time.use_zone("Pacific Time (US & Canada)") { (Time.zone.now.strftime("%H").to_i >= 12 && 1) || 0 },
+    ).order(price: :desc)
+  end
 end

--- a/spec/controllers/api/mentions_controller_spec.rb
+++ b/spec/controllers/api/mentions_controller_spec.rb
@@ -32,6 +32,7 @@ describe Api::MentionsController do
           expect_any_instance_of(AppMentionService).to receive(:post_message).with(
             channel: "C0LAN2Q65",
             text: "Thank you, <@#{user.slack_id}>! Your price of 123 bells has been successfully recorded.",
+            blocks: [],
           )
             .and_return({ ok: true })
         end
@@ -67,6 +68,7 @@ describe Api::MentionsController do
             channel: "C0LAN2Q65",
             text: "I'm sorry. I didn't quite get that. " \
                   "Please type `@MrStalky help` for a list of the commands I understand.",
+            blocks: [],
           )
             .and_return({ ok: true })
         end

--- a/spec/services/app_mention_service_spec.rb
+++ b/spec/services/app_mention_service_spec.rb
@@ -14,6 +14,7 @@ describe AppMentionService do
           channel: "C0LAN2Q65",
           text: "I'm sorry. I didn't quite get that. " \
             "Please type `@MrStalky help` for a list of the commands I understand.",
+          blocks: [],
         )
         .and_return({ ok: true })
 
@@ -28,13 +29,30 @@ describe AppMentionService do
       expect(described_class.new(payload[:event].merge(text: text), user).handle_message).to eq(nil)
     end
 
-    it "records turnip price when proper command and syntax is passed" do
+    it "responds to 'record' command" do
       text = "<@app_id> record 123"
 
       response = "Thank you, <@#{user.slack_id}>! Your price of 123 bells has been successfully recorded."
 
       expect(described_class.new(payload[:event].merge(text: text), user).handle_message).to eq(response)
-      expect(user.turnip_price_records.last.price).to eq(123)
+    end
+
+    it "responds to 'whatsup' command" do
+      travel_to Time.use_zone("Pacific Time (US & Canada)") { Time.zone.at(1_515_449_522.000016) }
+
+      user = create(
+        :user,
+        turnip_price_records: [create(:turnip_price_record, price: 123, date: "2018-01-08", time_period: 1)],
+      )
+      text = "<@app_id> whatsup"
+
+      expect(described_class.new(payload[:event].merge(text: text), user).handle_message).to eq(true)
+    end
+
+    it "returns nil if whatsup mention has more than one word" do
+      text = "<@app_id> whatsup friend"
+
+      expect(described_class.new(payload[:event].merge(text: text), user).handle_message).to eq(nil)
     end
 
     it "works regardless of casing" do
@@ -68,6 +86,80 @@ describe AppMentionService do
 
       expect(user.turnip_price_records.count).to eq(1)
       expect(user.turnip_price_records.last.price).to eq(130)
+    end
+  end
+
+  describe "#whatsup" do
+    it "displays the top turnip prices recorded for that time period" do
+      travel_to Time.use_zone("Pacific Time (US & Canada)") { Time.zone.at(1_515_449_522.000016) }
+
+      user = create(
+        :user,
+        turnip_price_records: [create(:turnip_price_record, price: 123, date: "2018-01-08", time_period: 1)],
+      )
+      text = "<@app_id> whatsup"
+
+      expect_any_instance_of(AppMentionService).to receive(:post_message)
+        .with(
+          channel: "C0LAN2Q65",
+          text: "",
+          blocks: [
+            {
+              type: "section",
+              text: {
+                text: "The *top* turnip prices recorded this time period",
+                type: "mrkdwn",
+              },
+              fields: [
+                {
+                  type: "mrkdwn",
+                  text: "*User*",
+                },
+                {
+                  type: "mrkdwn",
+                  text: "*Bells*",
+                },
+                {
+                  type: "mrkdwn",
+                  text: "<@#{user.slack_id}>",
+                },
+                {
+                  type: "plain_text",
+                  text: "123",
+                },
+              ],
+            },
+          ],
+        )
+        .and_return({ ok: true })
+
+      service = described_class.new(payload[:event].merge(text: text), user)
+      service.whatsup
+
+      expect(service.respond).to eq(true)
+    end
+
+    it "returns message if there are not any recorded turnip prices in the current time period" do
+      user = create(
+        :user,
+        turnip_price_records: [create(:turnip_price_record, price: 123, date: "2018-01-08", time_period: 1)],
+      )
+      text = "<@app_id> whatsup"
+
+      expect_any_instance_of(AppMentionService).to receive(:post_message)
+        .with(
+          channel: "C0LAN2Q65",
+          text: "I don't have any turnip prices at this time. " \
+            "Please type `@MrStalky record <price>` to record your turnip prices.",
+          blocks: [],
+        )
+        .and_return({ ok: true })
+
+      service = described_class.new(payload[:event].merge(text: text), user)
+
+      service.whatsup
+
+      expect(service.respond).to eq(true)
     end
   end
 end

--- a/spec/support/time_helpers.rb
+++ b/spec/support/time_helpers.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include ActiveSupport::Testing::TimeHelpers
+end


### PR DESCRIPTION
- Add `whatsup` as accepted command in `AppMentionService`
- Add `TurnipPriceRecord.top_turnip_prices` scope to return all top prices in the current time period
- Add `return_challenge` to `MentionsController` to ensure it will respond to validate itself to Slack when deployed to Heroku
- Add and improve tests